### PR TITLE
fixed problem with double driver prefix in credentials path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import fs from "fs";
 import { google, tasks_v1 } from "googleapis";
-import path from "path";
+import { join } from "path";
 import { TaskActions, TaskResources } from "./Tasks.js";
 
 const tasks = google.tasks("v1");
@@ -233,19 +233,12 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   throw new Error("Tool not found");
 });
 
-const credentialsPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
-  "../.gtasks-server-credentials.json",
-);
+const credentialsPath = join(process.cwd(), '.gtasks-server-credentials.json');
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
-  const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    "../gcp-oauth.keys.json",
-  );
-
-  console.log(p);
+  const p = join(process.cwd(), 'gcp-oauth.keys.json');
+  console.log("Credential Path:" + p);
   const auth = await authenticate({
     keyfilePath: p,
     scopes: ["https://www.googleapis.com/auth/tasks"],


### PR DESCRIPTION
@zcaceres @calclavia Greetings, I fixed the problem with calculating path for credentials in Windows, it was duplicating driver path in the path string.
I opened an Issues with more details if you were interested.
[Link to issue](https://github.com/zcaceres/gtasks-mcp/issues/11)

This is my first open source contribution and I'm really happy even if this does not get accepted. (another bro has added a PR request before me).