### PR TITLE
Normalize path parsing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import fs from "fs";
 import { google, tasks_v1 } from "googleapis";
 import path from "path";
 import { TaskActions, TaskResources } from "./Tasks.js";
+import { fileURLToPath } from "url";
 
 const tasks = google.tasks("v1");
 
@@ -233,17 +234,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   throw new Error("Tool not found");
 });
 
-const credentialsPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
-  "../.gtasks-server-credentials.json",
-);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const credentialsPath = path.join(__dirname, "../.gtasks-server-credentials.json");
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
-  const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    "../gcp-oauth.keys.json",
-  );
+  
+  const __filename = fileURLToPath(import.meta.url)
+  const __dirname = path.dirname(__filename);
+  const p = path.join(__dirname, "../gcp-oauth.keys.json");
 
   console.log(p);
   const auth = await authenticate({


### PR DESCRIPTION
Normalize OAuth keyfile and credentials paths for Windows.

eg: no such file or directory, open 'E:\E:\Program%20Files\MCPs\gtasks-mcp\.gtasks-server-credentials.json'