### PR TITLE
feat: add list-tasklists tool and fix OAuth token refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import fs from "fs";
 import { google, tasks_v1 } from "googleapis";
 import path from "path";
+import { fileURLToPath } from "url";
 import { TaskActions, TaskResources } from "./Tasks.js";
 
 const tasks = google.tasks("v1");
@@ -259,14 +260,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 const credentialsPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../.gtasks-server-credentials.json",
 );
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
   const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
+    path.dirname(fileURLToPath(import.meta.url)),
     "../gcp-oauth.keys.json",
   );
 
@@ -290,7 +291,9 @@ async function loadCredentialsAndRunServer() {
   const credentials = JSON.parse(fs.readFileSync(credentialsPath, "utf-8"));
 
   // Load OAuth app credentials to enable token refresh
-  const oauthKeysPath = path.join(path.dirname(credentialsPath), "gcp-oauth.keys.json");
+  // Support GOOGLE_OAUTH_CREDENTIALS env var for shared credential location
+  const oauthKeysPath = process.env.GOOGLE_OAUTH_CREDENTIALS ||
+    path.join(path.dirname(credentialsPath), "gcp-oauth.keys.json");
   const oauthKeys = JSON.parse(fs.readFileSync(oauthKeysPath, "utf-8"));
   const { client_id, client_secret } = oauthKeys.installed;
 


### PR DESCRIPTION
## Summary

This PR adds improvements and fixes to the gtasks MCP server:

### 1. New `list-tasklists` tool (Closes #3)
- Returns all task lists with their IDs
- Useful for discovering which `taskListId` to use with other operations

### 2. Fix OAuth token refresh
- Initialize OAuth2 client with `client_id` and `client_secret` to enable automatic token refresh
- Auto-save refreshed tokens to disk

### 3. Support `GOOGLE_OAUTH_CREDENTIALS` env var (Closes #18)
- Allows specifying a shared location for OAuth credentials
- Useful when sharing credentials with other Google MCP servers
- Falls back to default relative path if not set

### 4. Fix Windows path resolution (Closes #7, Closes #11)
- Use `fileURLToPath()` instead of `URL.pathname`
- Fixes the `C:\C:\...` path issue on Windows

### 5. Fix due date format for create/update (Closes #2)
- Normalize dates to RFC3339 format required by Google Tasks API
- Supports: date-only (`2026-01-15`), datetime (`2026-01-15T21:00:00`), and pre-formatted RFC3339
- Fixes "invalid argument" error when setting due dates on task creation

## Test plan

- [x] `list-tasklists` returns all task lists with IDs
- [x] Token refresh works when access token expires
- [x] `GOOGLE_OAUTH_CREDENTIALS` env var works (tested with explicit path)
- [x] Path resolution works on Linux (Windows fix uses standard `fileURLToPath` approach)
- [x] Due dates work with various formats: date-only, datetime without TZ, RFC3339
- [x] No breaking changes to existing tools

🤖 Generated with [Claude Code](https://claude.ai/code)