### PR TITLE
fix: pass client credentials to OAuth2 for token refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -262,8 +262,19 @@ async function loadCredentialsAndRunServer() {
     process.exit(1);
   }
 
+  const keysPath = path.join(
+    path.dirname(new URL(import.meta.url).pathname),
+    "../gcp-oauth.keys.json",
+  );
+  const keys = JSON.parse(fs.readFileSync(keysPath, "utf-8"));
+  const oauthConfig = keys.installed || keys.web;
+
   const credentials = JSON.parse(fs.readFileSync(credentialsPath, "utf-8"));
-  const auth = new google.auth.OAuth2();
+  const auth = new google.auth.OAuth2(
+    oauthConfig.client_id,
+    oauthConfig.client_secret,
+    oauthConfig.redirect_uris?.[0],
+  );
   auth.setCredentials(credentials);
   google.options({ auth });
 


### PR DESCRIPTION
## Summary
- OAuth2 client was created without `client_id` and `client_secret`, causing `"Could not determine client ID from request"` errors when the access token expires and needs refreshing
- Reads client credentials from `gcp-oauth.keys.json` and passes them to the `OAuth2` constructor

## Root Cause
`new google.auth.OAuth2()` without credentials works only while the initial access token is valid. Once it expires, the refresh request fails because Google's API cannot identify the application.

## Test plan
- [x] Verified fix resolves `invalid_request` error
- [x] Confirmed `tasklists.list()` and `tasks.list()` work after fix
- [x] Tested full MCP protocol flow (initialize → tools/call → list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)