### PR TITLE
Fix Windows path resolution, add env variable overrides

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,10 @@ import {
 import fs from "fs";
 import { google, tasks_v1 } from "googleapis";
 import path from "path";
+import { fileURLToPath } from "url";
 import { TaskActions, TaskResources } from "./Tasks.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const tasks = google.tasks("v1");
 
@@ -259,17 +262,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   throw new Error("Tool not found");
 });
 
-const credentialsPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
-  "../.gtasks-server-credentials.json",
-);
+const credentialsPath =
+  process.env.GOOGLE_TASKS_CREDENTIALS_PATH ||
+  path.join(__dirname, "../.gtasks-server-credentials.json");
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
-  const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    "../gcp-oauth.keys.json",
-  );
+  const p =
+    process.env.GOOGLE_OAUTH_KEYS_PATH ||
+    path.join(__dirname, "../gcp-oauth.keys.json");
 
   console.log(p);
   const auth = await authenticate({


### PR DESCRIPTION
## Summary

- Replace `new URL(import.meta.url).pathname` with `fileURLToPath(import.meta.url)` to fix `C:\C:\...` double-drive-letter bug on Windows
- Add `GOOGLE_OAUTH_KEYS_PATH` env variable to override the OAuth keys file location
- Add `GOOGLE_TASKS_CREDENTIALS_PATH` env variable to override the saved credentials location
- Closes #7, #10, #11, #18

## Test plan

- On Windows: `bun run src/index.ts auth` should resolve paths correctly (no `C:\C:\...`)
- With env vars: `GOOGLE_OAUTH_KEYS_PATH=/custom/path.json bun run src/index.ts auth` should use the custom path
- Without env vars: default relative paths still work as before