### PR TITLE
fix(auth): decode file URL path for credentials lookup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import {
 import fs from "fs";
 import { google, tasks_v1 } from "googleapis";
 import path from "path";
+import { fileURLToPath } from "url";
 import { TaskActions, TaskResources } from "./Tasks.js";
 
 const tasks = google.tasks("v1");
@@ -260,14 +261,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 });
 
 const credentialsPath = path.join(
-  path.dirname(new URL(import.meta.url).pathname),
+  path.dirname(fileURLToPath(import.meta.url)),
   "../.gtasks-server-credentials.json",
 );
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
   const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
+    path.dirname(fileURLToPath(import.meta.url)),
     "../gcp-oauth.keys.json",
   );
 


### PR DESCRIPTION
credentialsPath and the OAuth keyfile path were resolved via path.dirname(new URL(import.meta.url).pathname). URL.pathname returns a percent-encoded string, so any install directory containing a space (e.g. the default Claude Desktop Extensions path on macOS) never resolves. The server then reports "Credentials not found. Please run with 'auth' argument first." and exits, even when valid credentials exist at the correct location.

Fix: use fileURLToPath from node:url, which decodes the path correctly.

Verified by reproducing the failure from a path containing a space, then confirming the fix resolves and finds the credentials file correctly.