### PR TITLE
fix(auth): pass client credentials to OAuth2 token refresh

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -263,17 +263,15 @@ const credentialsPath = path.join(
   path.dirname(new URL(import.meta.url).pathname),
   "../.gtasks-server-credentials.json",
 );
+const oauthKeysPath = path.join(
+  path.dirname(new URL(import.meta.url).pathname),
+  "../gcp-oauth.keys.json",
+);
 
 async function authenticateAndSaveCredentials() {
   console.log("Launching auth flow…");
-  const p = path.join(
-    path.dirname(new URL(import.meta.url).pathname),
-    "../gcp-oauth.keys.json",
-  );
-
-  console.log(p);
   const auth = await authenticate({
-    keyfilePath: p,
+    keyfilePath: oauthKeysPath,
     scopes: ["https://www.googleapis.com/auth/tasks"],
   });
   fs.writeFileSync(credentialsPath, JSON.stringify(auth.credentials));
@@ -288,9 +286,18 @@ async function loadCredentialsAndRunServer() {
     process.exit(1);
   }
 
+  const { client_id, client_secret, redirect_uris } = JSON.parse(
+    fs.readFileSync(oauthKeysPath, "utf-8"),
+  ).installed;
   const credentials = JSON.parse(fs.readFileSync(credentialsPath, "utf-8"));
-  const auth = new google.auth.OAuth2();
+  const auth = new google.auth.OAuth2(client_id, client_secret, redirect_uris?.[0]);
   auth.setCredentials(credentials);
+  auth.on("tokens", (tokens) => {
+    fs.writeFileSync(
+      credentialsPath,
+      JSON.stringify({ ...credentials, ...tokens }),
+    );
+  });
   google.options({ auth });
 
   const transport = new StdioServerTransport();


### PR DESCRIPTION
The OAuth2 client is constructed with new google.auth.OAuth2() — no client_id or client_secret. This works while the initial access token is valid, but once it expires, the automatic refresh request to Google's token endpoint fails with invalid_request: Could not determine client ID from request., and every tool call fails despite a valid refresh token on disk.

Fix: read client_id, client_secret, and redirect_uris from gcp-oauth.keys.json and pass them to the OAuth2 constructor. Persist refreshed tokens back to the credentials file via the tokens event so later runs reuse the refreshed token and pick up a rotated refresh token if Google issues one.

Verified against a real expired token: reproduced the invalid_request failure with the old construction, then confirmed a live call to tasks.tasklists.list() succeeds and the tokens event fires with a refreshed access token.

Related to #34 (separate bug, same server), but independent of it.