### PR TITLE
feat: surface webViewLink on task output

### DIFF
--- a/src/Tasks.ts
+++ b/src/Tasks.ts
@@ -104,7 +104,7 @@ export class TaskResources {
 
 export class TaskActions {
   private static formatTask(task: tasks_v1.Schema$Task) {
-    return `${task.title}\n (Due: ${task.due || "Not set"}) - Notes: ${task.notes} - ID: ${task.id} - Status: ${task.status} - URI: ${task.selfLink} - Hidden: ${task.hidden} - Parent: ${task.parent} - Deleted?: ${task.deleted} - Completed Date: ${task.completed} - Position: ${task.position} - Updated Date: ${task.updated} - ETag: ${task.etag} - Links: ${task.links} - Kind: ${task.kind}}`;
+    return `${task.title}\n (Due: ${task.due || "Not set"}) - Notes: ${task.notes} - ID: ${task.id} - Status: ${task.status} - URI: ${task.selfLink} - WebViewLink: ${task.webViewLink || "None"} - Hidden: ${task.hidden} - Parent: ${task.parent} - Deleted?: ${task.deleted} - Completed Date: ${task.completed} - Position: ${task.position} - Updated Date: ${task.updated} - ETag: ${task.etag} - Links: ${task.links} - Kind: ${task.kind}}`;
   }
 
   private static formatTaskList(taskList: tasks_v1.Schema$Task[]) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
     `Position: ${task.position || "Unknown"}`,
     `ETag: ${task.etag || "Unknown"}`,
     `Links: ${task.links || "Unknown"}`,
+    `WebViewLink: ${task.webViewLink || "None"}`,
     `Kind: ${task.kind || "Unknown"}`,
     `Status: ${task.status || "Unknown"}`,
     `Created: ${task.updated || "Unknown"}`,


### PR DESCRIPTION
## Summary

The Google Tasks v1 API returns a `webViewLink` field on each task — a deep link into `tasks.google.com` for that specific task (e.g. `https://tasks.google.com/task/<opaque-id>?sa=6`). This field is useful for MCP clients that want to hand the user a direct link back into the Tasks web UI, but the current wrapper's formatters silently drop it.

This PR adds `webViewLink` to the two places tasks are rendered:

- `ReadResourceRequestSchema` handler in `src/index.ts` — the resource-details text block.
- `TaskActions.formatTask` in `src/Tasks.ts` — used by the `list` and `search` tools.

No type change was needed — `googleapis`' `tasks_v1.Schema$Task` already declares `webViewLink?: string | null`, so the field flows through the existing type.

## How I noticed

Fetching a task directly via `tasks.tasks.get` returned `webViewLink` in the raw body, but neither the MCP list/search output nor the resource read output surfaced it. Confirmed against a live account after the change — `webViewLink` now shows up on tasks that have one, and reads `None` on tasks that don't.

## Test plan

- [x] `bun build` succeeds.
- [x] Live `tools/call name=list` output contains a `WebViewLink: https://tasks.google.com/task/...` segment for at least one task.
- [x] Tasks without a `webViewLink` (e.g. very old ones) render `WebViewLink: None` rather than `undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)